### PR TITLE
#161290661 Change tooltip list-type

### DIFF
--- a/client/src/modules/Auth/components/ExtraForm.jsx
+++ b/client/src/modules/Auth/components/ExtraForm.jsx
@@ -30,15 +30,15 @@ const ExtraForm = ({
                 <i className="tooltip fa fa-question-circle" />
               </div>
               <div>
-                <div>
+                <div className="tooltip-padding">
                   <h5 className="">Need help getting slack ID?</h5>
                   <h6>Follow these simple steps</h6>
-                  <ul>
-                    <li><i className="far fa-dot-circle" /> &nbsp;Login to your slack account</li>
-                    <li><i className="far fa-dot-circle" /> &nbsp;At the top left corner, click on your name/username</li>
-                    <li><i className="far fa-dot-circle" /> &nbsp;From the pop up that appear, click on <b>Profile & Account</b> link</li>
-                    <li><i className="far fa-dot-circle" /> &nbsp;Click on <b>More actions</b> icon <img src="./resources/images/more1.png" height="13px" width="30px" alt="more" /></li>
-                    <li><i className="far fa-dot-circle" /> &nbsp;Click on <b>Copy member ID</b> to copy your slack membership ID(slack ID)</li>
+                  <ul className="li-style">
+                    <li>Login to your slack account</li>
+                    <li>At the top left corner, click on your name/username</li>
+                    <li>From the pop up that appear, click on <b>Profile & Account</b> link</li>
+                    <li>Click on <b>More actions</b> icon <img src="./resources/images/more1.png" height="13px" width="30px" alt="more" /></li>
+                    <li>Click on <b>Copy member ID</b> to copy your slack membership ID(slack ID)</li>
                   </ul>
                 </div>
               </div>

--- a/client/styles/components/_form.scss
+++ b/client/styles/components/_form.scss
@@ -35,6 +35,16 @@
   color: rgba(56, 93, 215, 0.98);
 }
 
-.l-style {
-  list-style-type:circle;
+.li-style{
+  padding-left: 2rem !important;
+  li {
+  list-style-type: square !important;
+}
+}
+
+.tooltip-padding {
+  padding: 1rem;
+}
+.mappleTip {
+  border: 1px solid #d4d4d5 !important;
 }


### PR DESCRIPTION
#### What does this PR do?

 - It changes tooltip list-type on the instruction of how to get slack Id

#### Description of Task to be completed?

- Added list type block on form.scss
- Modified ExtraForm components to include square list-type

#### How should this be manually tested?

- Navigate to review app
- Login using Andela email
- You will see a form with a tooltip with instructions of how to get slack Id

#### What are the relevant pivotal tracker stories?

[#161290661](https://www.pivotaltracker.com/story/show/161290661)

#### Screenshots or gifs (if appropriate)

<img width="868" alt="screen shot 2018-10-14 at 6 20 33 pm" src="https://user-images.githubusercontent.com/28547970/46935989-c114db80-d054-11e8-9f83-de4020ce095a.png">