### PR TITLE
#161293432 Implement creation of slack channel

### DIFF
--- a/client/src/modules/CreateTeam/components/Form.jsx
+++ b/client/src/modules/CreateTeam/components/Form.jsx
@@ -109,7 +109,8 @@ export const Form = ({
         </div>
         <div className="team-accounts top-margin">
           <img src={slack} className="integration-icon small-icon" alt="slack-image" />
-          <Dropdown placeholder="channel name" fluid multiple selection search options={slackOptions} />
+          <Dropdown
+            name="slack" onChange={menuChange} placeholder="channel name" fluid multiple selection search options={slackOptions} />
         </div>
         {!showSubmitButton && (
           <div className="submit-btn">

--- a/client/src/modules/CreateTeam/container/index.jsx
+++ b/client/src/modules/CreateTeam/container/index.jsx
@@ -41,7 +41,8 @@ export class CreateTeam extends Component {
       submitting: false,
       integrations: {
         github: [],
-        pt: []
+        pt: [],
+        slack: []
       }
     };
     this.handleChange = this.handleChange.bind(this);
@@ -150,7 +151,6 @@ export class CreateTeam extends Component {
               submitting={this.props.isFetching.isLoading}
             />
           </div>
-          }
         </div>
       </React.Fragment>
     );

--- a/client/src/redux/actions/teams/index.js
+++ b/client/src/redux/actions/teams/index.js
@@ -82,7 +82,8 @@ export const createTeam = data => async (dispatch) => {
 
     let integrationType = {
       github: 'github_repo',
-      pt: 'pt_private_project'
+      pt: 'pt_project',
+      slack: 'slack_private_channel'
     };
 
     // all selected integrations
@@ -97,10 +98,10 @@ export const createTeam = data => async (dispatch) => {
     const response = await api('teams', 'post', teamInfo);
     allRequest.team = [...allRequest.team, { created: true, name: data.name }];
     if (integrationExist) {
-      let allProject = Object.keys(projects);
-      for (let integration of allProject) {
-        for (let accountName of projects[integration]) {
-          let integrationInfo = {
+      const allProject = Object.keys(projects);
+      for (const integration of allProject) {
+        for (const accountName of projects[integration]) {
+          const integrationInfo = {
             name: accountName,
             type: integrationType[integration]
           };

--- a/client/src/tests/__mocks__/__mockData__/createTeamMock.js
+++ b/client/src/tests/__mocks__/__mockData__/createTeamMock.js
@@ -1,74 +1,106 @@
 const createTeamMock = {
-    createTeamResponse: {
-      data: {
-        team: {
-          containsYou: true,
-          id: 2
-        }
+  createTeamResponse: {
+    data: {
+      team: {
+        containsYou: true,
+        id: 2
       }
-    },
-    createTeamErrResponse: {
-      data: {
-        errors: ['The name field is required.']
+    }
+  },
+  createTeamErrResponse: {
+    data: {
+      errors: ['The name field is required.']
+    }
+  },
+  teamResposne: {
+    data: {
+      team: {
+        containsYou: true
       }
-    },
-    emptyTeamName: {
-      name: '',
-      description: 'lagos cohort 32',
-      private: 'private',
-      integrations: {
-        github: []
-      }
-    },
-    teamInfoData: {
-      name: 'ghoulie',
-      description: 'lagos cohort 32',
-      private: 'private',
-      integrations: {
-        github: []
-      }
-    },
-    createTeamData: {
-      name: 'ghoulie',
-      description: 'lagos cohort 32',
-      private: 'private'
-    },
-    createGithubData: {
-      name: 'ghoulie',
-      description: 'lagos cohort 32',
-      private: 'private',
-      integrations: {
-        github: ['ah-ghoulie']
-      }
-    },
-    githubResponse: {
-      data: {
-        created: true
-      }
-    },
-    githubData: {
-      name: 'ah-ghoulie',
-      type: 'github_repo'
-    },
-    ptResponse: {
-      data: {
-        created: true
-      }
-    },
-    ptData: {
-      name: 'ah-ghoulie',
-      type: 'pt_private_project'
-    },
-    createPtData: {
-      name: 'ghoulie',
-      description: 'lagos cohort 32',
-      private: 'private',
-      integrations: {
-        pt: ['ah-ghoulie']
-      }
-    },
-  
-  };
-  
-  export default createTeamMock;
-  
+    }
+  },
+  emptyTeamName: {
+    name: '',
+    description: 'lagos cohort 32',
+    private: 'private',
+    integrations: {
+      github: []
+    }
+  },
+  teamInfoData: {
+    name: 'ghoulie',
+    description: 'lagos cohort 32',
+    private: 'private',
+    integrations: {
+      github: []
+    }
+  },
+  createTeamData: {
+    name: 'ghoulie',
+    description: 'lagos cohort 32',
+    private: 'private'
+  },
+  createGithubData: {
+    name: 'ghoulie',
+    description: 'lagos cohort 32',
+    private: 'private',
+    integrations: {
+      github: ['ah-ghoulie']
+    }
+  },
+  githubResponse: {
+    data: {
+      created: true
+    }
+  },
+  githubData: {
+    name: 'ah-ghoulie',
+    type: 'github_repo'
+  },
+  ptResponse: {
+    data: {
+      created: true
+    }
+  },
+  ptData: {
+    name: 'ah-ghoulie',
+    type: 'pt_project'
+  },
+  createPtData: {
+    name: 'ghoulie',
+    description: 'lagos cohort 32',
+    private: 'private',
+    integrations: {
+      pt: ['ah-ghoulie']
+    }
+  },
+  slackData: {
+    name: 'ghoulie-general',
+    type: 'slack_private_channel'
+  },
+  createSlackData: {
+    name: 'ghoulie',
+    description: 'lagos cohort 32',
+    private: 'private',
+    integrations: {
+      slack: ['ghoulie-general']
+    }
+  },
+  slackResponse: {
+    data: {
+      created: true
+    }
+  },
+  integrationData: {
+    name: 'ghoulie',
+    description: 'lagos cohort 32',
+    private: 'private',
+    integrations: {
+      slack: ['ghoulie-general'],
+      pt: ['ah-ghoulie'],
+      github: ['ah-ghoulie']
+    }
+  }
+};
+
+export default createTeamMock;

--- a/client/src/tests/redux/actions/teams/index.test.js
+++ b/client/src/tests/redux/actions/teams/index.test.js
@@ -74,6 +74,28 @@ describe('Create Team actions', () => {
     expect(store.getActions()).toEqual(expectedActions);
   });
 
+  it('creates a slack channel', async () => {
+    const {
+      slackResponse, createSlackData, createTeamData,
+      createTeamResponse, slackData
+    } = createTeamMock;
+    const expectedActions = [{ "name": "OLUWAFEMI", "payload": true, "type": "[auth]: check if user is logged in" },
+      { "payload": true, "type": "[ui]: show preloader" }, { "payload": false, "type": "[ui]: show preloader" },
+      {
+        "payload": { "slack": [{ "created": true, "name": "ghoulie-general" }], "team": [{ "created": true, "name": "ghoulie" }] },
+        "type": SHOW_RESPONSE
+      }];
+    const store = mockStore({});
+    await mock
+      .onPost('teams', createTeamData)
+      .reply(201, createTeamResponse);
+    await mock
+      .onPost('teams/2/accounts', slackData)
+      .reply(201, slackResponse);
+    await store.dispatch(createTeam(createSlackData));
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+
   it('fails to create a team with empty name input', async () => {
     const { createTeamErrResponse, emptyTeamName } = createTeamMock;
     const expectedActions = [{ "name": "OLUWAFEMI", "payload": true, "type": "[auth]: check if user is logged in" },
@@ -84,6 +106,28 @@ describe('Create Team actions', () => {
       .onPost('teams', emptyTeamName)
       .reply(201, createTeamErrResponse);
     await store.dispatch(createTeam(emptyTeamName));
+    expect(store.getActions()).toEqual(expectedActions);
+  });
+
+  it(`fails to create github, slack and pivotal tracker projects
+   when there is no team ID`, async () => {
+    const { teamResposne, createTeamData, integrationData } = createTeamMock;
+    const expectedActions = [{ "name": "OLUWAFEMI", "payload": true, "type": "[auth]: check if user is logged in" },
+      { "payload": true, "type": "[ui]: show preloader" }, { "payload": false, "type": "[ui]: show preloader" },
+      {
+        "payload": {
+          "github": [{ "created": false, "name": "ah-ghoulie" }],
+          "pt": [{ "created": false, "name": "ah-ghoulie" }],
+          "slack": [{ "created": false, "name": "ghoulie-general" }],
+          "team": [{ "created": true, "name": "ghoulie" }]
+        },
+        "type": SHOW_RESPONSE
+      }];
+    const store = mockStore({});
+    await mock
+      .onPost('teams', createTeamData)
+      .reply(201, teamResposne);
+    await store.dispatch(createTeam(integrationData));
     expect(store.getActions()).toEqual(expectedActions);
   });
 });


### PR DESCRIPTION
#### What does this PR do?

- add functionality to create slack channels.

#### Description of Task to be completed?

- add functionality to create multiple slack channels on create team form.

#### How should this be manually tested?

- Login to the [review app](https://ghoulies-taps-client-pr-37.herokuapp.com/) as an admin
- Click on the create-team icon on the navigation panel
- Fill in valid form credentials and select 1(one) or more slack channel name
- Click on the submit button.

#### What are the relevant pivotal tracker stories?

[#161293432](https://www.pivotaltracker.com/story/show/161293432)

#### Screenshots (if appropriate)

<img width="1143" alt="screen shot 2018-10-15 at 1 11 19 pm" src="https://user-images.githubusercontent.com/23261181/46950823-f386fe80-d07d-11e8-8078-a097e8740ba3.png">=