### PR TITLE
#161318988 Add project-name field to create-team form

### DIFF
--- a/client/src/modules/CreateTeam/components/Form.jsx
+++ b/client/src/modules/CreateTeam/components/Form.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Dropdown } from 'semantic-ui-react';
+import { getInitials, formatWord } from '../../../utils/format';
+import { githubOptions, ptOptions, slackOptions } from '../../../utils/conventions';
 import slack from '../../../../public/resources/images/slack.png';
 import pt from '../../../../public/resources/images/pt.jpg';
 
@@ -13,41 +15,37 @@ export const Form = ({
   handleChange,
   name,
   desc,
-  checked,
+  project,
   handleSubmit,
   submitting,
-  menuChange
+  menuChange,
+  integrations
 }) => {
   let showSubmitButton = false;
   let teamName = 'example';
+  let showDropDown = true;
+  let projectName = project;
+  let slackDropdown = [];
+  let githubDropdown = [];
+  let ptDropdown = [];
 
   if (name.trim() && desc.trim()) {
     showSubmitButton = true;
+    showDropDown = false;
+    teamName = formatWord(name).toLowerCase();
+    slackDropdown = slackOptions(teamName);
+    ptDropdown = ptOptions(teamName);
+    githubDropdown = githubOptions(teamName);
   }
 
-  if (name.trim()) {
-    teamName = name;
+  if (project.trim()) {
+    teamName = formatWord(name).toLowerCase();
+    projectName = getInitials(project).toLowerCase();
+    slackDropdown = slackOptions(teamName, projectName);
+    ptDropdown = ptOptions(teamName, projectName);
+    githubDropdown = githubOptions(teamName, projectName);
   }
 
-  // github dropdown options
-  const githubOptions = [
-    { key: `ah-${teamName}-frontend`, text: `ah-${teamName}-frontend`, value: `ah-${teamName}-frontend` },
-    { key: `ah-${teamName}`, text: `ah-${teamName}`, value: `ah-${teamName}` },
-    { key: `${teamName}-ah`, text: `${teamName}-ah`, value: `${teamName}-ah` },
-    { key: `ah-${teamName}-backend`, text: `ah-${teamName}-backend`, value: `ah-${teamName}-backend` }
-  ];
-
-  const ptOptions = [
-    { key: `ah-${teamName}`, text: `ah-${teamName}`, value: `ah-${teamName}` },
-    { key: `${teamName}-ah`, text: `${teamName}-ah`, value: `${teamName}-ah` }
-  ];
-
-  const slackOptions = [
-    { key: `ah-${teamName}`, text: `ah-${teamName}`, value: `ah-${teamName}` },
-    { key: `${teamName}-general`, text: `${teamName}-general`, value: `${teamName}-general` },
-    { key: `${teamName}-standups`, text: `${teamName}-standups`, value: `${teamName}-standups` },
-    { key: `${teamName}-bots`, text: `${teamName}-bots`, value: `${teamName}-bots` }
-  ];
 
   return (
     <form
@@ -95,22 +93,44 @@ export const Form = ({
             <label>Team visibility</label>
           </div>
         </div>
+        <div className="row">
+          <div className="input-field col s12">
+            <input
+              id="project"
+              required
+              name="project"
+              type="text"
+              className="validate"
+              value={project}
+              onChange={handleChange}
+            />
+            <label className="active" htmlFor="project">Project name</label>
+          </div>
+        </div>
         <div className="team-accounts top-margin">
           <i className="fab fa-github integration-icon">`</i>
           <Dropdown
+            disabled={showDropDown || submitting}
+            value={integrations['github']}
             name="github" onChange={menuChange} placeholder="Repo name"
-            fluid multiple selection search options={githubOptions} />
+            fluid multiple selection search options={githubDropdown} />
         </div>
         <div className="team-accounts top-margin">
           <img src={pt} className="integration-icon small-icon" alt="pt-image" />
           <Dropdown
+            disabled={showDropDown || submitting}
+            value={integrations['pt']}
             name="pt" onChange={menuChange} placeholder="PT name"
-            fluid multiple selection search options={ptOptions} />
+            fluid multiple selection search options={ptDropdown} />
         </div>
         <div className="team-accounts top-margin">
           <img src={slack} className="integration-icon small-icon" alt="slack-image" />
           <Dropdown
-            name="slack" onChange={menuChange} placeholder="channel name" fluid multiple selection search options={slackOptions} />
+            disabled={showDropDown || submitting}
+            value={integrations['slack']}
+
+            name="slack" onChange={menuChange} placeholder="channel name"
+            fluid multiple selection search options={slackDropdown} />
         </div>
         {!showSubmitButton && (
           <div className="submit-btn">
@@ -140,9 +160,11 @@ export const Form = ({
 
 Form.propTypes = {
   handleChange: PropTypes.func.isRequired,
+  menuChange: PropTypes.func.isRequired,
+  project: PropTypes.string.isRequired,
+  integrations: PropTypes.object.isRequired,
   name: PropTypes.string.isRequired,
   desc: PropTypes.string.isRequired,
-  checked: PropTypes.bool.isRequired,
   handleSubmit: PropTypes.func.isRequired,
   submitting: PropTypes.bool.isRequired
 };

--- a/client/src/modules/CreateTeam/container/index.jsx
+++ b/client/src/modules/CreateTeam/container/index.jsx
@@ -37,6 +37,7 @@ export class CreateTeam extends Component {
     this.state = {
       name: '',
       description: '',
+      project: 'authors haven',
       visibility: false,
       submitting: false,
       integrations: {
@@ -103,7 +104,12 @@ export class CreateTeam extends Component {
    */
   handleChange(event) {
     this.setState({
-      [event.target.name]: event.target.value
+      [event.target.name]: event.target.value,
+      integrations: {
+        github: [],
+        slack: [],
+        pt: []
+      }
     });
   }
 
@@ -129,7 +135,8 @@ export class CreateTeam extends Component {
 
   render() {
     const {
-      name, description, visibility, github
+      name, description, visibility, github,
+      project, integrations
     } = this.state;
     const { showModal } = this.props.teams;
     return (
@@ -144,7 +151,9 @@ export class CreateTeam extends Component {
               handleSubmit={this.handleSubmit}
               handleChange={this.handleChange}
               menuChange={this.menuChange}
+              integrations={integrations}
               name={name}
+              project={project}
               desc={description}
               checked={visibility}
               github={github}

--- a/client/src/tests/modules/CreateTeam/components/Form.test.jsx
+++ b/client/src/tests/modules/CreateTeam/components/Form.test.jsx
@@ -7,8 +7,14 @@ describe('Create Team Form', () => {
   const props = {
     handleSubmit: jest.fn(),
     handleChange: jest.fn(),
+    integrations: {
+      github: [],
+      slack: [],
+      pt: []
+    },
     name: 'taps-client',
     desc: 'taps-client',
+    project: 'author haven',
     checked: true,
     submitting: true
   };

--- a/client/src/tests/modules/createTeams/component/form.test.js
+++ b/client/src/tests/modules/createTeams/component/form.test.js
@@ -8,6 +8,12 @@ describe('CreateTeam Form test-suite', () => {
     name: 'jude',
     desc: 'cohort 56',
     checked: 'false',
+    project: 'card for humanity',
+    integrations: {
+      github: [],
+      slack: [],
+      pt: []
+    },
     handleSubmit: jest.fn(),
     submitting: false,
     menuChange: jest.fn()

--- a/client/src/utils/conventions.js
+++ b/client/src/utils/conventions.js
@@ -1,0 +1,24 @@
+export const githubOptions = (teamName, projectName = 'ah') => (
+  [
+    { key: `${projectName}-${teamName}-frontend`, text: `${projectName}-${teamName}-frontend`, value: `${projectName}-${teamName}-frontend` },
+    { key: `${projectName}-${teamName}-git`, text: `${projectName}-${teamName}`, value: `${projectName}-${teamName}` },
+    { key: `${teamName}-${projectName}-github`, text: `${teamName}-${projectName}`, value: `${teamName}-${projectName}` },
+    { key: `${projectName}-${teamName}-backend`, text: `${projectName}-${teamName}-backend`, value: `${projectName}-${teamName}-backend` }
+  ]
+);
+
+export const ptOptions = (teamName, projectName = 'ah') => (
+  [
+    { key: `${projectName}-${teamName}-pt`, text: `${projectName}-${teamName}`, value: `${projectName}-${teamName}` },
+    { key: `${teamName}-${projectName}-gen`, text: `${teamName}-${projectName}`, value: `${teamName}-${projectName}` }
+  ]
+);
+
+export const slackOptions = (teamName, projectName = 'ah') => (
+  [
+    { key: `${projectName}-${teamName}`, text: `${projectName}-${teamName}`, value: `${projectName}-${teamName}` },
+    { key: `${teamName}-general`, text: `${teamName}-general`, value: `${teamName}-general` },
+    { key: `${teamName}-standups`, text: `${teamName}-standups`, value: `${teamName}-standups` },
+    { key: `${teamName}-bots`, text: `${teamName}-bots`, value: `${teamName}-bots` }
+  ]
+);

--- a/client/src/utils/format.js
+++ b/client/src/utils/format.js
@@ -1,0 +1,7 @@
+export const getInitials = (word) => {
+  // b=positon w=matches any word g=repeat the word through all string
+  let matches = word.match(/\b(\w)/g);
+  return matches.join('');
+};
+
+export const formatWord = (word) => word.replace(/\s/g, '-');

--- a/client/styles/components/_create_team.scss
+++ b/client/styles/components/_create_team.scss
@@ -14,10 +14,24 @@
     height: 5rem;
 }
 
+.select-wrapper+label {
+    margin-top: 0.4rem
+}
+
 .select-wrapper {
     ul {
         top: 37px !important
     }
+}
+
+.form-wrapper {
+    margin-bottom: 1rem
+}
+
+.input-field {
+    position: relative;
+    margin-top: 0.4rem;
+    margin-bottom: 0.75rem;
 }
 
 .team-accounts {


### PR DESCRIPTION
#### What does this PR do?

- add project-name input field to create-team form

#### Description of Task to be completed?

- add project-name input field to create-team form
- set default project-name to `authors haven`

#### How should this be manually tested?

- Login to the app as an admin
- Click on the create-team icon on the navigation panel

#### What are the relevant pivotal tracker stories?

[#161318988](https://www.pivotaltracker.com/story/show/161318988)

#### Screenshots (if appropriate)

<img width="1377" alt="screen shot 2018-10-17 at 2 55 38 pm" src="https://user-images.githubusercontent.com/23261181/47091432-c6248700-d21c-11e8-81a1-d0432c1fa329.png">