### PR TITLE
#161316640 corrects route bug

### DIFF
--- a/client/src/routes/AuthRoute.jsx
+++ b/client/src/routes/AuthRoute.jsx
@@ -1,0 +1,24 @@
+
+import React from 'react';
+import { Route, Redirect } from 'react-router-dom';
+
+
+const isLoggedIn = () => localStorage.getItem('aTeamsToken') &&
+    localStorage.getItem('userId') &&
+    localStorage.getItem('role');
+
+const AuthRoute = ({ component: Component, ...rest }) => (
+  <Route
+    {...rest}
+    render={(props) => {
+      if (isLoggedIn()) {
+        return <Redirect to="/teams" />;
+      }
+      return <Component {...props} />;
+    }}
+  />
+);
+
+
+export default AuthRoute;
+

--- a/client/src/routes/index.jsx
+++ b/client/src/routes/index.jsx
@@ -2,15 +2,15 @@ import React, { Component } from 'react';
 import { BrowserRouter, Route, Switch } from 'react-router-dom';
 import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
-
+import SignInContainer from '../modules/Auth/container';
 // components
 import Favorite from '../modules/Teams/components/FavoriteTeams';
 import Home from '../modules/Home/container';
 import Preloader from '../modules/common/Preloader';
-import SignIn from '../modules/Auth/container';
 import CreateTeam from '../modules/CreateTeam/container';
 import Teams from '../modules/Teams/container';
 import RequireAuth from './RequireAuth';
+import AuthRoute from './AuthRoute';
 
 export default class Routes extends Component {
   componentDidMount() {
@@ -31,8 +31,8 @@ export default class Routes extends Component {
           <Switch>
             <Route path="/teams/favorites" exact component={RequireAuth(Favorite)} />
             <Route path="/teams" exact component={Home} />
-            <Route path="/" exact component={SignIn} />
             <Route path="/teams/create" component={RequireAuth(CreateTeam)} />
+            <AuthRoute path="/" exact component={SignInContainer} />
             <Route path="/teams/:id" exact component={RequireAuth(Teams)} />
           </Switch>
         </React.Fragment>

--- a/client/src/tests/__mocks__/mockLocalStorage.js
+++ b/client/src/tests/__mocks__/mockLocalStorage.js
@@ -7,4 +7,8 @@ export default {
   removeItem(key) {
    return delete localStorage[key]; //eslint-disable-line
   },
+
+  getItem(key) {
+    return localStorage[key];
+  }
 };

--- a/client/src/tests/routes/AuthRoute.test.jsx
+++ b/client/src/tests/routes/AuthRoute.test.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { shallow } from "enzyme";
+import { Route, Redirect } from 'react-router-dom';
+import AuthRoute from "../../../src/routes/AuthRoute";
+import mockLocalStorage from '../__mocks__/mockLocalStorage';
+
+global.localStorage = mockLocalStorage;
+
+const SampleComponent = () => <div />;
+const getShallow = (props = {}) => shallow(<AuthRoute {...props} />);
+
+describe('Testing AuthRoute Route type', () => {
+  describe('components rendered', () => {
+    it('should match snapShot', () => {
+      const shallowObj = getShallow();
+      expect(shallowObj).toMatchSnapshot();
+    });
+
+    it('should always render a Route component', () => {
+      const shallowObj = getShallow();
+      expect(shallowObj.find(Route)
+        .length).toBe(1);
+    });
+
+
+    it('should render a SignIn component when user is not logged in', () => {
+      global.localStorage.setItem('userId', '');
+      global.localStorage.setItem('role', '');
+      global.localStorage.setItem('aTeamsToken', '');
+
+      const shallowObj = getShallow({ component: SampleComponent });
+      expect(shallowObj.find(Route)
+        .length).toBe(1);
+      const renderFn = shallowObj.find(Route)
+        .prop('render');
+      const renderedComponent = renderFn();
+      expect(renderedComponent.type)
+        .toBe(SampleComponent);
+    });
+    it('should render a Redirect when the user is logged in', () => {
+      global.localStorage.setItem('userId', 'mock-user-id');
+      global.localStorage.setItem('role', 'member');
+      global.localStorage.setItem('aTeamsToken', 'mock-team-toke');
+      const shallowObj = getShallow();
+      expect(shallowObj.find(Route)
+        .length).toBe(1);
+      const renderFn = shallowObj.find(Route)
+        .prop('render');
+      const renderedComponent = renderFn();
+      expect(renderedComponent.type)
+        .toBe(Redirect);
+    });
+  });
+});
+

--- a/client/src/tests/routes/__snapshots__/AuthRoute.test.jsx.snap
+++ b/client/src/tests/routes/__snapshots__/AuthRoute.test.jsx.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing AuthRoute Route type components rendered should match snapShot 1`] = `
+<Route
+  render={[Function]}
+/>
+`;


### PR DESCRIPTION
#### What does this PR do?

- adds AuthRoute Route type
- routes logged-in users to '/teams'
- adds tests for the AuthRoute
- ensures that tests added have 100% coverage
- updates mockLocalStorage to have a getItem method
- makes AuthRoute a higher order component

#### Description of Task to be completed?

- logged-in users should be redirected to `/teams` when they manually route to `/`

#### How should this be manually tested?

- once a user is logged in and manually routes to `/`, the user is taken back to `/teams`

#### Any background context you want to provide?

- users can currently manually route to the login page even after they are logged-in

#### What are the relevant pivotal tracker stories?

[#161316640](https://www.pivotaltracker.com/story/show/161316640)